### PR TITLE
Chore: Tighten MyPy checks (phase 1)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True
+
+# Phase 1 tightening: enable safe warnings only
+# Future phases may set:
+#   no_implicit_optional = True
+#   disallow_incomplete_defs = True
+#   disallow_untyped_defs = True
+#   check_untyped_defs = True


### PR DESCRIPTION
Introduce a baseline mypy.ini with safe warnings enabled:\n- warn_unused_ignores\n- warn_redundant_casts\n- warn_unused_configs\n- ignore_missing_imports (for third-party libs)\n\nThis is the first step towards stricter typing without breaking current builds. CI continues to run \mypy src\ and will now pick up the config automatically. Future phases will consider enabling \
o_implicit_optional\, \disallow_incomplete_defs\, and \disallow_untyped_defs\ module-by-module.