### PR TITLE
Chore: MyPy phase 2 — disallow untyped defs in src.budget

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,6 @@ warn_unused_configs = True
 #   disallow_incomplete_defs = True
 #   disallow_untyped_defs = True
 #   check_untyped_defs = True
+
+[mypy-src.budget]
+disallow_untyped_defs = True


### PR DESCRIPTION
Phase 2 of incremental typing hardening.

Changes:
- mypy.ini: add per-module rule for src.budget — disallow_untyped_defs = True.

Notes:
- Keeps scope small and non-breaking; no code changes required because src.budget already has annotations.
- Future phases: expand to additional modules (e.g., src.rate_limiter, src.scheduler), one at a time.

Once this lands, I’ll prep phase 3 with another module.