### PR TITLE
Chore: MyPy phase 3 — disallow untyped defs in src.reliability

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,3 +14,6 @@ warn_unused_configs = True
 
 [mypy-src.budget]
 disallow_untyped_defs = True
+
+[mypy-src.reliability]
+disallow_untyped_defs = True


### PR DESCRIPTION
Phase 3 of incremental typing hardening.

Changes:
- mypy.ini: add per-module rule for src.reliability — disallow_untyped_defs = True.

Notes:
- Low risk, the module is already fully annotated.
- Next: expand to src.rate_limiter or src.scheduler, module-by-module, fixing any surfaced annotations as we go.