### PR TITLE
chore(mypy): phase 4 — disallow_untyped_defs for src.rate_limiter

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ disallow_untyped_defs = True
 
 [mypy-src.reliability]
 disallow_untyped_defs = True
+
+[mypy-src.rate_limiter]
+disallow_untyped_defs = True

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,29 @@
+"""Lightweight logging helpers used across the project.
+
+Provides a minimal, typed interface for getting and configuring loggers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def configure_logging(level: int | str = "INFO") -> None:
+    """Configure basic logging for the application.
+
+    Accepts either a logging level int or a case-insensitive string name.
+    """
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a module-level logger.
+
+    If name is None, returns the root logger.
+    """
+    return logging.getLogger(name)


### PR DESCRIPTION
Enable per-module mypy tightening for src.rate_limiter (disallow_untyped_defs). Also adds a small typed logger helper to keep imports consistent and typed.\n\n- Tests: 14 passed locally\n- Mypy: CI runs mypy on src; rate_limiter now fully typed for defs\n- Scope: config-only + tiny helper; no behavior changes\n\nAuto-merge will be enabled once checks pass.