### PR TITLE
chore(mypy): phase 5 — disallow_untyped_defs for src.scheduler

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -20,3 +20,6 @@ disallow_untyped_defs = True
 
 [mypy-src.rate_limiter]
 disallow_untyped_defs = True
+
+[mypy-src.scheduler]
+disallow_untyped_defs = True


### PR DESCRIPTION
Phase 5 of incremental mypy tightening.

- Enable disallow_untyped_defs for src.scheduler
- Config-only change; functions already typed
- Tests: 14 passed locally

Auto-merge will be enabled once checks pass.