### PR TITLE
chore(dev): add local mypy scripts (parity with CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ python tests/live_test.py --confirm
 python tests/test_learning.py
 ```
 
+## 🧑‍💻 Local dev tips
+
+Type checking (parity with CI):
+
+```bash
+# macOS/Linux
+./scripts/mypy.sh
+
+# Windows PowerShell
+./scripts/mypy.ps1
+```
+
 ## 📚 Key Improvements
 
 ### Over agent-x

--- a/scripts/mypy.ps1
+++ b/scripts/mypy.ps1
@@ -1,0 +1,5 @@
+# Runs mypy against src for parity with CI
+param()
+
+# Ensure mypy is installed in the active environment
+mypy src

--- a/scripts/mypy.sh
+++ b/scripts/mypy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs mypy against src for parity with CI
+mypy src


### PR DESCRIPTION
Add simple scripts to run 'mypy src' locally and a short README note:\n\n- scripts/mypy.sh (macOS/Linux)\n- scripts/mypy.ps1 (Windows PowerShell)\n\nThis aligns local dev with CI's 'mypy src'.