### PR TITLE
chore: enable disallow_untyped_defs for src.x_client (Phase 12)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ disallow_untyped_defs = True
 
 [mypy-src.auth]
 disallow_untyped_defs = True
+
+[mypy-src.x_client]
+disallow_untyped_defs = True


### PR DESCRIPTION
Phase 12 of incremental mypy tightening.

Enables \disallow_untyped_defs = True\ for \src.x_client\ module.

**Changes:**
- Updated \mypy.ini\ with \[mypy-src.x_client]\ section
- Removed redundant type:ignore comments (relying on ignore_missing_imports)
- Fixed variable redefinition: moved \esults\ declaration before if/else block
- Added type cast for AuthMode validation in \rom_env()\

**Validation:**
- ✅ All 14 tests pass
- ✅ MyPy type-checking clean (only informational requests stub notes)
- ✅ No runtime behavior changes