### PR TITLE
chore: remove unused type:ignore comments

### DIFF
--- a/src/budget.py
+++ b/src/budget.py
@@ -163,7 +163,7 @@ class BudgetManager:
         """
         return cls(
             storage=storage,
-            plan=config.get("plan", "free"),  # type: ignore
+            plan=config.get("plan", "free"),
             buffer_pct=config.get("buffer_pct", 0.05),
             custom_read_cap=config.get("custom_read_cap"),
             custom_write_cap=config.get("custom_write_cap"),

--- a/src/reliability.py
+++ b/src/reliability.py
@@ -22,7 +22,7 @@ from typing import Any
 try:
     import requests
 except ImportError:  # pragma: no cover
-    requests = None  # type: ignore
+    requests = None
 
 
 DEFAULT_TIMEOUT = 10.0  # seconds

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -68,7 +68,7 @@ def run_post_action(
     else:
         # Check budget first
         from budget import BudgetManager
-        budget_mgr = BudgetManager(storage=storage, plan=config.get("plan", "free"))  # type: ignore
+        budget_mgr = BudgetManager(storage=storage, plan=config.get("plan", "free"))
         can_write, msg = budget_mgr.can_write(1)
         if not can_write:
             logger.warning(f"Budget check failed: {msg}")
@@ -129,7 +129,7 @@ def run_interact_actions(
         limits["follow"] = 0
 
     # Jitter bounds
-    jitter_bounds = tuple(config.get("jitter_seconds", [8, 20]))  # type: ignore
+    jitter_bounds = tuple(config.get("jitter_seconds", [8, 20]))
 
     # Execute for each query
     for query_item in queries:


### PR DESCRIPTION
Cleanup of unused type:ignore comments that were causing mypy warnings.

**Changes:**
- Removed unused type:ignore from \src/reliability.py\ (line 25)
- Removed unused type:ignore from \src/budget.py\ (line 166)
- Removed unused type:ignore from \src/scheduler.py\ (lines 71, 132)

These comments became redundant due to \ignore_missing_imports = True\ in global mypy config.

**Validation:**
- ✅ All 14 tests pass
- ✅ MyPy clean (only informational stub notes remain)
- ✅ No runtime behavior changes